### PR TITLE
feat: Add repository scan mode to CVE Half-Day Watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ More information can be found on our [blog](https://blog.aquasec.com/50-shades-o
 CVE Half-Day Watcher scans the NVD for newly pushed CVEs and checks for any GitHub references such as commits, pull requests (PRs), or issues linked to these CVEs.
 It then verifies if the commit/PR has been included in a release on GitHub (currently for issue it skips this check). If a release including the fix is not available, it flags the CVE to indicate a possible "half-day" vulnerability scenario, where the vulnerability is known but not yet patched.
 
+The tool now also scans titles and bodies of open PRs and issues in specified GitHub repositories using a suspicious word-matching algorithm. This feature aims to alert maintainers early about potential security risks that could impact their codebase.
+
+
+
 ## Installation
 
 Before you begin, ensure you have Python installed on your system. Then, clone the repository and install the dependencies:
@@ -30,7 +34,10 @@ pip install -r requirements.txt
 ```
 
 ## Usage
-To use CVE Half-Day Watcher, you will need a GitHub token (without permissions).
+The CVE Half-Day Watcher can be used in two modes: scanning newly published CVEs from the NVD and scanning specific repositories for potentially malicious content.
+
+## NVD Scan Mode
+This mode scans the National Vulnerability Database (NVD) for newly published CVEs with GitHub references.
 
 ```bash
 python scan_nvd.py --github_token YOUR_GITHUB_TOKEN [--days DAYS] [--min_stars MIN_STARS]
@@ -42,3 +49,12 @@ python scan_nvd.py --github_token YOUR_GITHUB_TOKEN [--days DAYS] [--min_stars M
 An example of the results from November 2, 2023.
 ![5_half_day_2_x2.png](/misc/5_half_day_2_x2.png)
 
+## Repository Scan Mode
+This mode scans titles and bodies of open PRs and issues in specified GitHub repositories using a suspicious word-matching algorithm.
+
+```bash
+python scan_repo.py --github_token YOUR_GITHUB_TOKEN --repo_full_name YOUR_REPO_NAME
+```
+
+* --github_token: Your GitHub token for authentication (required).
+* --repo_full_name: Your Github repo name in the format: <Organization name/Repository Name> for example: 'aqua-Nautilus/CVE-Half-Day-Watcher' (required)


### PR DESCRIPTION
This commit adds a new feature to the CVE Half-Day Watcher tool, allowing it to scan titles and bodies of open PRs and issues in specified GitHub repositories using a suspicious word-matching algorithm. This feature aims to alert maintainers early about potential security risks that could impact their codebase.